### PR TITLE
Removed the non-standard GLSL mix call in Gizmo.shader + Optimization

### DIFF
--- a/src/main/res/shaders/Gizmo.shader
+++ b/src/main/res/shaders/Gizmo.shader
@@ -11,7 +11,6 @@ out vec3 VertColor;
 
 void main()
 {
-    vec3 fullMask = vec3(1.0);
     vec3 halfMask = vec3(0.6);
 
     vec3 white = vec3(1.0, 1.0, 1.0);
@@ -24,11 +23,12 @@ void main()
     VertColor = aColor;
     VertColor = round(VertColor);
     
-    VertColor *= mix(halfMask, fullMask, 
-           (VertColor == white
-        || (VertColor * handleActive.x) == red
-        || (VertColor * handleActive.y) == green
-        || (VertColor * handleActive.z) == blue));
+    if (VertColor != white && 
+        (VertColor * handleActive.x) != red &&
+        (VertColor * handleActive.y) != green &&
+        (VertColor * handleActive.z) != blue) {
+        VertColor *= halfMask;
+    }
 }
 #shader fragment
 #version 330 core

--- a/src/main/res/shaders/Gizmo.shader
+++ b/src/main/res/shaders/Gizmo.shader
@@ -11,24 +11,33 @@ out vec3 VertColor;
 
 void main()
 {
-    vec3 halfMask = vec3(0.6);
+    const vec3 fullMask = vec3(1.0);
+    const vec3 halfMask = vec3(0.6);
 
-    vec3 white = vec3(1.0, 1.0, 1.0);
-    vec3 red = vec3(1.0, 0.0, 0.0);
-    vec3 green = vec3(0.0, 1.0, 0.0);
-    vec3 blue = vec3(0.0, 0.0, 1.0);
+    const vec3 white = vec3(1.0, 1.0, 1.0);
+    const vec3 red = vec3(1.0, 0.0, 0.0);
+    const vec3 green = vec3(0.0, 1.0, 0.0);
+    const vec3 blue = vec3(0.0, 0.0, 1.0);
 
     gl_Position = uVP * vec4(aPos.x, aPos.y, aPos.z, 1.0);
 
     VertColor = aColor;
     VertColor = round(VertColor);
+
+    // Calculate the comparison results as floats (1.0 for true, 0.0 for false)
+    float isWhite = float(all(equal(VertColor, white)));
+    float isRed = float(all(equal(VertColor * handleActive.x, red)));
+    float isGreen = float(all(equal(VertColor * handleActive.y, green)));
+    float isBlue = float(all(equal(VertColor * handleActive.z, blue)));
+
+    // Combine the results
+    float mask = isWhite + isRed + isGreen + isBlue;
+
+    // Clamp the mask to ensure it's either 0.0 or 1.0
+    mask = clamp(mask, 0.0, 1.0);
     
-    if (VertColor != white && 
-        (VertColor * handleActive.x) != red &&
-        (VertColor * handleActive.y) != green &&
-        (VertColor * handleActive.z) != blue) {
-        VertColor *= halfMask;
-    }
+    // Perform the mix operation using the calculated mask
+    VertColor *= mix(halfMask, fullMask, mask);
 }
 #shader fragment
 #version 330 core


### PR DESCRIPTION
My AMD-based PC couldn't compile the Gizmo.shader due to the non-standard GLSL mix function call.

Before the change, the third parameter was a boolean, after evaluation. I think some GPU driver implementations automatically cast that to 1.0 if the boolean is true, or 0.0 if it's false, but that is non-standard behavior from what I've read.

Instead of passing 0.0 or 1.0 explicitly in the mix function as an interpolation factor, I decided to remove it completely and instead only multiply `VertColor` with the `halfMask` when needed. We get the same highlight behavior on the gizmos but we skip the mix call, so it should be faster.

I can adjust my current implementation if you want, just let me know.